### PR TITLE
Simplify love.js module lookup

### DIFF
--- a/src/targets/web.ts
+++ b/src/targets/web.ts
@@ -2,7 +2,6 @@ import { IPaths, ITarget } from "../conf/targets";
 import { exec } from "child_process";
 import { join } from "path";
 import { zip } from "zip-a-folder";
-import { platform } from "os";
 import * as fse from "fs-extra";
 
 export default async function packageLove(
@@ -13,19 +12,11 @@ export default async function packageLove(
   const unpackedDir = join(paths.tmp, "web-unpacked");
   fse.emptydirSync(unpackedDir);
 
-  const nodeModulesPath = await new Promise<string>((res, rej) => {
-    exec(`cd ${__dirname} && npm root`, (err, data) => {
-      if (err) return rej(err);
-      res(data.replace("\n", "").replace("\r", ""));
-    });
-  });
-
-  const loveJsName = platform() == "win32" ? "love.js.cmd" : "love.js";
-  const loveJsPath = join(nodeModulesPath, ".bin", loveJsName);
+  const loveJsPath = require.resolve("love.js");
 
   await new Promise((res, rej) => {
     exec(
-      `${loveJsPath} ${paths.tmpLove} ${unpackedDir} -t "${config.name}" -c`,
+      `node ${loveJsPath} ${paths.tmpLove} ${unpackedDir} -t "${config.name}" -c`,
       (err) => {
         if (err) return rej(err);
         res(null);


### PR DESCRIPTION
## Issue

On Windows the love.js module lookup finds an incorrect folder (` PATH_TO_WORKSPACE\node_modules\love-packager\node_modules\.bin\love.js.cmd` vs `PATH_TO_WORKSPACE\node_modules\.bin\love.js.cmd`).

## Solution

I updated the web target to use node's built-in resolution mechanism (`require.resolve`) and call love.js's main script manually.

I tested this on Windows 11, but don't currently have easy access to test on other systems.